### PR TITLE
fix: handle arith correctly

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -114,9 +114,17 @@ class Arith extends Op {
   }
 
   gen(emit) {
+    if (this.withPA) {
+      emit('(');
+    }
+
     this.expr1.gen(emit);
     emit(' ' + this.token.spelling + ' ');
     this.expr2.gen(emit);
+
+    if (this.withPA) {
+      emit(')');
+    }
   }
 }
 

--- a/test/boolex.test.js
+++ b/test/boolex.test.js
@@ -123,4 +123,10 @@ describe('boolex', function () {
     expect(fn({count: 5})).to.be(true);
     expect(fn({count: 6})).to.be(false);
   });
+
+  it('(@count1 + @count2) * 2 == 22 should ok', function () {
+    var fn = boolex.compile('(@count1 + @count2) * 2 == 22');
+    expect(fn({count1: 5, count2: 6})).to.be(true);
+    expect(fn({count1: 5, count2: 5})).to.be(false);
+  });
 });


### PR DESCRIPTION
When boolex <= v2.1.0, the dsl:

```
(@count1 + @count2) * 2
```

will be compiled to:

```js
function (context) {
  // (@count1 + @count2) * 2
  return context.count1 + context.count2 * 2;
}
```

, and actually it should be:

```js
function (context) {
  // (@count1 + @count2) * 2
  return (context.count1 + context.count2) * 2;
}
```

